### PR TITLE
fix footer links, assuming /c5-zine is the root

### DIFF
--- a/source/_footer_page.erb
+++ b/source/_footer_page.erb
@@ -5,6 +5,6 @@
   Past Issues:
   <% ["issue1", "issue2", "issue3", "issue4",
   "issue5"].each_with_index do |issue, index| %>
-    <a class="past-issues__link" href="<%= issue %>" ><%= index + 1%></a>
+    <a class="past-issues__link" href="/<%= issue %>" ><%= index + 1%></a>
   <% end %>
 </div>


### PR DESCRIPTION
# Problem
Footer links go to 404 because they are appending the destination name incorrectly:
_ex:  https://carbonfive.github.io/c5-zine/issue5/issue3_

# Solution
Although, I cannot test this locally, since the app runs from `http://localhost` instead of `http://localhost/c5-zine`
just adding "/" _should_ use **carbonfive.github.io/c5-zine/** as the root and yield the correct URL:
https://carbonfive.github.io/c5-zine/issue3/