### PR TITLE
Fix issue with past links in github pages deploy

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -30,8 +30,4 @@ pages = data.issue7.pages
   <%= partial("footer_page") %>
 </footer>
 
-<script type="text/javascript">
- document.addEventListener("DOMContentLoaded", function() {
-   document.querySelector(".nav-item__print-button").addEventListener("click", function() { window.print(); } );
- });
-</script>
+<!-- JS is available in site.js -->

--- a/source/javascripts/site.js
+++ b/source/javascripts/site.js
@@ -1,1 +1,32 @@
 // This is where it all goes :)
+function attachPrintListener() {
+  document
+    .querySelector(".nav-item__print-button")
+    .addEventListener("click", function () {
+      window.print();
+    });
+}
+
+// fix up links for github pages deployment
+function directoryDepth(path) {
+  return path.match(/(\/)/).length - 1;
+}
+
+function attachPastLinkListener() {
+  document
+    .querySelectorAll(".past-issues__link[href]")
+    .forEach(function (link) {
+      if (directoryDepth(window.location.pathname) > 0) {
+        const directories = window.location.pathname.split("/").slice(0, -2);
+        directories.push(link.getAttribute("href"));
+        const newPath = directories.join("/");
+        link.addEventListener("click", function (ev) {
+          ev.preventDefault();
+          window.location.href = newPath;
+        });
+      }
+    });
+}
+
+document.addEventListener("DOMContentLoaded", attachPrintListener);
+document.addEventListener("DOMContentLoaded", attachPastLinkListener);

--- a/source/stylesheets/_zine.scss
+++ b/source/stylesheets/_zine.scss
@@ -10,6 +10,10 @@
   margin: 0 auto;
 }
 
+.footer {
+  margin-bottom: 30px;
+}
+
 .zine {
   + .zine {
     margin-top: 0;


### PR DESCRIPTION
Problem
--------

Because when we deploy to gh pages, links are no longer based off of `/`
but are nested under our repo name, in this case `/c5-zine` like
`/c5-zine/issue4`.  This works fine for the first link, but once you're
on a past issue (`/c5-zine/issue4`) when you click the link for
*another* past issue, you get `/c5-zine/issue4/issue3`.

This case is specific to gh-pages deployment.  We cannot know the
deployment strategy when the app runs because it's static.  If we build
links that will work for gh-pages, then local development with the
middleman server don't work.

See Issue #8

Solution
---------

We can use a little bit of javascript that looks at the current path
when you're browsing the page.  If that path has more than 1 level, we
use that path to generate the new past link path by replacing the last
part of the path with the new href.

This should work unless we start adding some deeper paths than the
top-level.

Fixes #8

Changes
-------

* Move javascript from index.html.erb into the `site.js`
* Add a listener that is attached to all `past-issue__link`s which
  builds the past issue link based on the current path and the desired
  href and intercepts the click to take the user to the right place

Verification
-----------

* `bundle exec rake build`
* from root `python3 -m http.server` (or however you'd like to start up a simple file system http server)
* navigate to `localhost:8000/build/` - notice how this path structure matches roughly the gh-pages deployment.
* click a past issue.
* click another one.  You should be in the right place.  

If you follow these steps on master, the second click on a past issue would get you a 404.