### PR TITLE
Fix nav links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,12 @@ task :deploy do
   system("mgd")
 end
 
-desc "Run middleman server"
-task :serve do
-  system("middleman server")
-end
-
 desc "Run middleman build"
 task :build do
   system("middleman build")
+end
+
+desc "Run middleman server"
+task :serve do
+  system("middleman server")
 end

--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,5 @@
 # Activate and configure extensions
 # https://middlemanapp.com/advanced/configuration/#configuring-extensions
-
 activate :autoprefixer do |prefix|
   prefix.browsers = "last 2 versions"
 end
@@ -51,3 +50,4 @@ page '/*.txt', layout: false
 activate :directory_indexes
 activate :relative_assets
 activate :asset_hash
+set :relative_links, true

--- a/source/_footer_page.erb
+++ b/source/_footer_page.erb
@@ -5,6 +5,6 @@
   Past Issues:
   <% ["issue1", "issue2", "issue3", "issue4",
       "issue5", "issue6", "issue7"].each_with_index do |issue, index| %>
-    <a class="past-issues__link" href="<%= issue %>" ><%= index + 1%></a>
+    <%= link_to (index+1), issue, class: "past-issues__link" %>
   <% end %>
 </div>

--- a/source/_navigation.html.erb
+++ b/source/_navigation.html.erb
@@ -4,14 +4,10 @@
       <button class="nav-item__print-button" title="Print Me!" ><i class="nav-item__print-button-icon"></i></button>
     </li>
     <li class="nav-item nav-item__info">
-      <a class="nav-item__info-link" href="info" target="_blank">
-        <i class="nav-item__info-icon"></i>
-      </a>
+      <%= link_to '<i class="nav-item__info-icon"></i>', "info", class: "nav-item__info-link", target:"_blank" %>
     </li>
     <li class="nav-item nav-item__info">
-      <a class="nav-item__info-link" href="/" target="_blank">
-        <i class="nav-item__home-icon"></i>
-      </a>
+      <%= link_to '<i class="nav-item__home-icon"></i>', "/", class: "nav-item__info-link", target:"_blank" %>
     </li>
   </ol>
 </nav>

--- a/source/issue7.html.erb
+++ b/source/issue7.html.erb
@@ -7,19 +7,6 @@ asset_dir = data.issue7.asset_dir
 pages = data.issue7.pages
 %>
 
-<nav class="nav">
-  <ol class="nav__items">
-    <li class="nav-item nav-item__print">
-      <button class="nav-item__print-button" title="Print Me!" ><i class="nav-item__print-button-icon"></i></button>
-    </li>
-    <li class="nav-item nav-item__info">
-      <a class="nav-item__info-link" href="info" target="_blank">
-        <i class="nav-item__info-icon"></i>
-      </a>
-    </li>
-  </ol>
-</nav>
-
 <main class="zine-sheet-count-<%= (pages.length.to_f / 8).ceil.to_i %>">
   <%= partial "sheet", locals: { pages: pages[0..7], sheet: 1, asset_dir: asset_dir } %>
   <% if pages.length > 8 %>


### PR DESCRIPTION
As it turns out, middleman has the notion of relative links which I
thought i'd turned on but it only works if you use the `link_to` helper
which I was not using.

Solution
--------

Use the `link_to` helper and turn `relative_links` on for everything.

Hopefully addresses #14