### PR TITLE
Fix mis-titled entries

### DIFF
--- a/source/issue13.html.erb
+++ b/source/issue13.html.erb
@@ -1,5 +1,5 @@
 ---
-"title": "C5 Zine - Issue 13 - Dawn"
+"title": "C5 Zine - Issue 13 - Full Circle"
 ---
 
 <%

--- a/source/issue3.html.erb
+++ b/source/issue3.html.erb
@@ -1,5 +1,5 @@
 ---
-"title": "C5 Zine - Issue 3 - Shelter In Place"
+"title": "C5 Zine - Issue 3 - Where You At?"
 ---
 
 <%


### PR DESCRIPTION
Problem
---------

As we moved from issue to issue, and added a helper script
`scripts/setup_next_issue.rb`, we may have missed updating html
titles for a couple of issues.

Solution
--------

Update the missed title updates for issue 3 and issue 13